### PR TITLE
Resolve PHP 8.4 deprecation requiring nullable to be explicit

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -773,7 +773,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  array|null  $except
      * @return \Jenssegers\Model\Model
      */
-    public function replicate(array $except = null)
+    public function replicate(?array $except = null)
     {
         $except = $except ?: [];
 


### PR DESCRIPTION
The `replicate` method causes a deprecation error as it isn't explicitly marked as nullable, this PR resolves that issue by marking it as nullable.